### PR TITLE
feat: askar wallet에 저장하여 등록한 schema를 불러오는 기능

### DIFF
--- a/controllers/user.ts
+++ b/controllers/user.ts
@@ -1,22 +1,21 @@
 import { RequestHandler } from 'express';
 import {checkAllInputs} from './utils/checkInput';
+import faber from '../src/Faber';
 import Email from '../models/email';
 
 const join :RequestHandler=async (req,res,next)=>{ //VC발급
     
     if(checkAllInputs(req.body)){
-        const {email, wallet, name} = req.body; 
-        console.log(email,wallet,name)
+        const {email, name} = req.body; 
+        console.log(email,name)
         try{
             const exEmail = await Email.findOne({where:{email}}); //이메일 검증 확인
 
             if(exEmail && exEmail.isValid && !exEmail.isRegistered){
                 await exEmail.update({isValid:false, isRegistered:true}); //다른 사람이 동일한 이메일로 가입하는 것을 방지
-
-                // const faber:Faber = container.resolve("faber");
-                // await faber.setupConnection(); // p2p연결
-                // await faber.issueCredential({email,name,tel}); // p2p연결완료 시 VC발급(email, name, tel)
-                return res.redirect('/?message=success');
+                await faber.setupConnection(); // p2p연결
+                await faber.issueCredential({email,name}); // p2p연결완료 시 VC발급(email, name, tel)
+                return res.redirect('/?message=증명서 발급이 완료되었습니다. 요청을 승락해주세요.');
             }
             else{
             return res.redirect(`/?error=이메일 인증을 먼저 해주세요`);
@@ -31,4 +30,10 @@ const join :RequestHandler=async (req,res,next)=>{ //VC발급
     }  
 }
 
-export {join}
+const logIn:RequestHandler=async (req,res,next)=>{
+    console.log(req.body);
+
+    return 
+}
+
+export {join,logIn}

--- a/middlewares/index.ts
+++ b/middlewares/index.ts
@@ -1,0 +1,16 @@
+import faber from "../src/Faber"
+import { RequestHandler } from 'express';
+
+
+const sendProofRequest:RequestHandler = async (req,res,next) =>{
+
+    if(!faber.listener.on){
+        await faber.setupConnection(); 
+        await faber.sendProofRequest();
+        res.send("waiting for acceptance")
+    }else{
+        next(req.body);
+    }
+};
+
+export{sendProofRequest};

--- a/public/scripts/join.js
+++ b/public/scripts/join.js
@@ -19,6 +19,12 @@ const validateEmail = function() {
     } 
 };
 
+const signIn = function(){
+    axios.post('/users/login').then((res)=>{
+      
+    })
+}
+
 $(document).ready(()=> {
   const btn= $('<button/>', {
     text: 'email 검증하기',

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -1,8 +1,12 @@
 import express from 'express';
-import {join} from '../controllers/user';
+import {join,logIn} from '../controllers/user';
+import { sendProofRequest } from '../middlewares';
 const router = express.Router();
 
-//POST /users
-router.post('/',join)
+//POST /users/join
+router.post('/join',join);
+
+//POST /users/login
+router.post('/login',sendProofRequest,logIn);
 
 export {router};

--- a/src/BaseAgent.ts
+++ b/src/BaseAgent.ts
@@ -82,7 +82,7 @@ export class BaseAgent {
         id: name,
         key: process.env.BCOVRINSEED as string,
       },
-      endpoints: [`${process.env.URL}:${this.port}`],
+      endpoints: [`${process.env.URL}`],
       //autoUpdateStorageOnStartup:true,
     } satisfies InitConfig
     this.config = config
@@ -95,7 +95,6 @@ export class BaseAgent {
     this.agent.registerInboundTransport(new HttpInboundTransport({ port }))
     this.agent.registerOutboundTransport(new HttpOutboundTransport())
     this.agent.registerOutboundTransport(new WsOutboundTransport())
-    console.log("BaseAgent Construct")
   }
 public async createDid():Promise<string>{ //indy bcovrin did 생성방법
   await this.agent.dids.import({ //did값을 넣으면 외부에서 생성한 did를 import할 수 있다. internal 방식으로 create할려면 endoser의 did와 seed가 wallet에 등록되어잇어야한다.
@@ -132,7 +131,7 @@ public async initializeAgent() {
 }
 
 const getAskarAnonCredsIndyModules=()=>{
-  const mediatorInvitationUrl =process.env.MEDIATORINVITATIONURL
+  //const mediatorInvitationUrl =process.env.MEDIATORINVITATIONURL
   const legacyIndyCredentialFormatService = new LegacyIndyCredentialFormatService()
     const legacyIndyProofFormatService = new LegacyIndyProofFormatService()
     return {
@@ -178,9 +177,9 @@ const getAskarAnonCredsIndyModules=()=>{
       ariesAskar: new AskarModule({
         ariesAskar,
       }),
-      mediationRecipient: new MediationRecipientModule({
-        mediatorInvitationUrl,
-      }),
+      // mediationRecipient: new MediationRecipientModule({
+      //   mediatorInvitationUrl,
+      // }),
     } as const
   }
  

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -1,0 +1,42 @@
+
+import faber from "./Faber";
+import type {
+  BasicMessageStateChangedEvent,
+  CredentialExchangeRecord,
+  CredentialStateChangedEvent,
+  ProofExchangeRecord,
+  ProofStateChangedEvent,
+} from '@aries-framework/core'
+import {
+  BasicMessageEventTypes,
+  BasicMessageRole,
+  CredentialEventTypes,
+  CredentialState,
+  ProofEventTypes,
+  ProofState,
+} from '@aries-framework/core'
+
+export class Listener{
+  public on: boolean
+  public constructor() {
+    this.on = false
+  }
+  public proofAcceptListener(){
+    faber.agent.events.on(ProofEventTypes.ProofStateChanged, async ({ payload }: ProofStateChangedEvent) => {
+      if (payload.proofRecord.state === ProofState.PresentationReceived) {
+        this.on=true;
+        console.log(payload.proofRecord)
+        this.on=false;
+      }
+    })
+  }
+
+  public messageListener() {
+    faber.agent.events.on(BasicMessageEventTypes.BasicMessageStateChanged, async (event: BasicMessageStateChangedEvent) => {
+      if (event.payload.basicMessageRecord.role === BasicMessageRole.Receiver) {
+        console.log(`\n received a message: ${event.payload.message.content}\n`)
+      }
+    })
+  }
+
+}

--- a/src/interfaces/IIssueCredentialInfo.ts
+++ b/src/interfaces/IIssueCredentialInfo.ts
@@ -1,5 +1,4 @@
 export interface IIssueCredentialInfo{
         email : string;
         name : string;
-        wallet : string;
 }

--- a/src/interfaces/IItemObject.ts
+++ b/src/interfaces/IItemObject.ts
@@ -1,0 +1,3 @@
+export interface IItemObject{
+    [key:string]:any;
+}

--- a/views/users/join.ejs
+++ b/views/users/join.ejs
@@ -16,7 +16,7 @@
     <div class="container right-panel-active">
         <!-- Sign Up -->
         <div class="container__form container--signup">
-            <form action="/users" method="post" class="form" id="form1">
+            <form action="/users/join" method="post" class="form" id="form1">
                 <h2 class="form__title">Sign Up</h2>
                 <input type="text" placeholder="User" class="input" id="name" name="name" required />
                 <div class="row" style="width: 100%;">
@@ -26,21 +26,16 @@
                   <div class="p-0 email-validation" id="email-validation">
                   </div>
                 </div>
-                <input type="text" placeholder="Wallet" class="input" id="wallet" name="wallet" required/>
-                <button class="join_btn" type="submit" >Sign Up</button>
-                <button class="join_btn" type="button" id="btn_look_around">회원가입 없이</button>
+                <div class="row" style="width: 100%;">
+                  <button class="join_btn col-md-6" type="submit" >Sign Up</button>
+                <button class="join_btn col-md-6" type="button" id="btn_look_around">without signing up</button>
+                </div>
           </form>
         </div>
       
         <!-- Sign In -->
         <div class="container__form container--signin">
-          <form action="#" class="form" id="form2">
-            <h2 class="form__title">Sign In</h2>
-            <input type="email" placeholder="Email" class="input" required/>
-            <input type="password" placeholder="Password" class="input" required/>
-            <a href="#" class="link">Forgot your password?</a>
-            <button class="join_btn">Sign In</button>
-          </form>
+            <button class="join_btn" type="button" onclick="signIn()">Sign In</button>
         </div>
       
         <!-- Overlay -->


### PR DESCRIPTION
## feat: askar wallet에 저장하여 등록한 schema를 불러오는 기능 #9
```
const schemaRecord = await this.getById(CustomRecord,"user-schema");
    if(!schemaRecord){
      const schema = await this.registerSchema();
      this.saveItems("user-schema",schema);
    }
    const vcCount = await this.getById(CustomRecord,"vc-count");
    if(!vcCount){
      this.saveItems('vc-count',{key:0});
    }
```
- credential을 발급할때마다 동일한 schema를 중복 발급을 막는다.

```
const vcCount = await this.getById(CustomRecord,"vc-count").then((el)=>{return el?.metadata.data});;
    
    const { credentialDefinitionState } =
      await this.agent.modules.anoncreds.registerCredentialDefinition<IndyVdrRegisterCredentialDefinitionOptions>({
        credentialDefinition: {
          schemaId,
          issuerId: this.anonCredsIssuerId,
          tag: String(vcCount?.key[0]),
        },
        options: {
          //supportRevocation: false,
          endorserMode: 'internal',
          endorserDid: process.env.BCOVRINENDORSERDID as string
        },
      })

      const nCount = vcCount?.key[0]+1;
    
      await this.updateItem('vc-count',{key:nCount});
```
- 동일한 schemaId, issuerId에 대해서는 credentialDefinitionID가 동일하므로(중복되면 안됨)
-  tag값을 주어 매 credential마다 변동을 준다.