### PR TITLE
fix: 효율적인 투표방 상태확인을 위한 주기적인 ntp 서버요청

### DIFF
--- a/roomScheduler/utils/time.go
+++ b/roomScheduler/utils/time.go
@@ -11,6 +11,7 @@ func GetCurrentTime() (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
+	seoulTime := currentTime.In(time.FixedZone("Asia/Seoul", 9*3600))
 
-	return currentTime, nil
+	return seoulTime, nil
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,11 +2,9 @@ FROM node:18.19.0
 
 COPY ./package.json /myfolder/
 WORKDIR /myfolder/
-
 RUN yarn install
-
 COPY . /myfolder/
 
 # 컨테이너가 종료되지 않도록 대기 상태 유지
-CMD ["tail", "-f", "/dev/null"]
+CMD tail -f /dev/null
 # CMD ["npm", "run", "start"]

--- a/web/src/agent/BaseAgent.ts
+++ b/web/src/agent/BaseAgent.ts
@@ -96,7 +96,7 @@ public async createDid():Promise<string>{ //indy bcovrin did 생성방법
       },
     ],
     overwrite:true,
-  })
+  });
   const indyDocument: DidCreateResult = await this.agent.dids.create({
     method: 'indy',
     // the secret contains a the verification method type and id

--- a/web/src/agent/Faber.ts
+++ b/web/src/agent/Faber.ts
@@ -353,7 +353,7 @@ class Faber extends BaseAgent {
             //schema_id:schema?.schemaId[0],
             //schema_issuer_id:this.anonCredsIssuerId,
             issuer_id: this.anonCredsIssuerId,
-            cred_def_id: this.credentialDefinition?.credentialDefinitionId,
+            //cred_def_id: this.credentialDefinition?.credentialDefinitionId,
           },
         ],
       },

--- a/web/src/agent/Listener.ts
+++ b/web/src/agent/Listener.ts
@@ -2,21 +2,15 @@
 import faber from "./Faber";
 import type {
   BasicMessageStateChangedEvent,
-  CredentialExchangeRecord,
-  CredentialStateChangedEvent,
-  ProofExchangeRecord,
   ProofStateChangedEvent,
 } from '@aries-framework/core'
 import {
   BasicMessageEventTypes,
   BasicMessageRole,
-  CredentialEventTypes,
-  CredentialState,
   ProofEventTypes,
   ProofState,
 } from '@aries-framework/core'
-import { decodeBase64 } from "../controllers/utils";
-import { EventEmitter } from "stream";
+import { decodeBase64 } from "../utils";
 
 export class Listener{
   

--- a/web/src/controllers/auth.ts
+++ b/web/src/controllers/auth.ts
@@ -1,10 +1,9 @@
 import { RequestHandler } from 'express';
 import crypto from 'crypto';
 import Email from '../models/email';
-import {transporter} from '../configs/email';
 import {successHtml, errMail, successMail, alreadyVerifiedHtml} from '../configs/email';
 import { IMailOptions } from './interfaces/IMailOptions';
-import { sendMail } from './utils';
+import { sendMail } from '../utils';
 
 const generateEmailVerificationToken = ()=>{
     const token = crypto.randomUUID();

--- a/web/src/controllers/page.ts
+++ b/web/src/controllers/page.ts
@@ -1,11 +1,12 @@
 import { RequestHandler } from "express";
-import { getCurrentTime } from "./utils";
 import { Moment } from "moment-timezone";
+import { cachedTime } from "../utils/time";
+import moment from 'moment';
 
 
 const getCreateRoom:RequestHandler = async (req,res,next)=>{
     try{
-        const currentTime:Moment = await getCurrentTime();
+        const currentTime:Moment = moment(cachedTime);
         const startTime = currentTime.format("YYYY-MM-DDTHH:mm");
         const startTimeEnd = currentTime.add(2,'month').format("YYYY-MM-DDTHH:mm");
         const endTime = currentTime.add(1,'hours').format("YYYY-MM-DDTHH:mm");

--- a/web/src/controllers/user.ts
+++ b/web/src/controllers/user.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express';
-import {checkAllInputs, getCurrentTime} from './utils/index';
+import {checkAllInputs} from '../utils/index';
 import bcrypt from 'bcrypt';
 import axios from 'axios';
 import faber from '../agent/Faber';
@@ -125,7 +125,7 @@ const vpAuth:RequestHandler=async(req,res,next)=>{
     const transaction = await sequelize.transaction();
 
     try{
-        /*vc발급 주체는 검증.*/
+        /*vc발급 주체 검증.*/
         res.write(`${JSON.stringify({"progress":"VP검증중..."})}`);
         sendProofRequest(req,res,next);
         const vp =  await faber.listener.proofAcceptListener();

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -13,6 +13,7 @@ import passport from 'passport';
 import passportConfig from './middlewares/passport';
 import dotenv from 'dotenv';
 import nocache from 'nocache';
+import { startTimeUpdate } from './utils/time';
 
 dotenv.config();
 const app = express();
@@ -58,6 +59,7 @@ app.use((req,res,next)=>{
   res.locals.isAuthenticated = auth; 
   next();
 })
+startTimeUpdate(60000);
 app.use('/',pageRouter);
 app.use('/rooms',voteRoomRouter);
 app.use('/auth',authRouter);

--- a/web/src/routes/users.ts
+++ b/web/src/routes/users.ts
@@ -8,7 +8,7 @@ const router = express.Router();
 router.post('/join',isNotLoggedIn,join);
 
 //POST /users/vote/:room_id
-router.post('/vote/:room_id',isLoggedIn,connection,checkRoomStatus,vpAuth);
+router.post('/vote/:room_id',connection,checkRoomStatus,vpAuth);
 
 //POST /users/vote-right/:room_id
 router.post('/vote-right/:room_id',isLoggedIn,connection,didAuth,issueVoteVC);

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,8 +1,6 @@
-import {transporter} from '../../configs/email';
-import { ICandidate, ICandidates } from '../interfaces/ICandidate';
-import { IMailOptions } from '../interfaces/IMailOptions';
-import ntpClient from 'ntp-client';
-import moment, { Moment } from 'moment-timezone';
+import {transporter} from '../configs/email';
+import { ICandidate, ICandidates } from '../controllers/interfaces/ICandidate';
+import { IMailOptions } from '../controllers/interfaces/IMailOptions';
 
 export const hasOwnProperty=(obj:Object, prop:any) => {
     return Object.prototype.hasOwnProperty.call(obj, prop);
@@ -64,21 +62,4 @@ export const fromBase64 = (base64:string) =>{
       bytes[i] = binaryString.charCodeAt(i);
   }
   return bytes;
-}
-
-export const getCurrentTime = (): Promise<Moment>=>{
-  return new Promise((resolve, reject) => {
-    ntpClient.getNetworkTime("pool.ntp.org", 123, (err, date) => {
-      if (err) {
-        console.error("NTP 서버에서 시간을 가져오는 데 실패했습니다.", err);
-        reject(err);  // 에러 발생 시 Promise를 reject
-        return;
-      }
-      
-      let seoulTime = moment(date).tz("Asia/Seoul");
-      seoulTime = seoulTime.set({minute:0, second: 0, millisecond: 0 });
-      console.log("NTP 서버에서 받은 시간 (서울 시간):", seoulTime);
-      resolve(seoulTime);  // 성공 시 Promise를 resolve
-    });
-  });
 }

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,0 +1,41 @@
+import ntpClient from 'ntp-client';
+import moment from 'moment-timezone';
+
+export let cachedTime:Date;
+
+const getCurrentTime = (): Promise<Date>=>{
+    return new Promise((resolve, reject) => {
+      ntpClient.getNetworkTime("pool.ntp.org", 123, (err, date) => {
+        if (err) {
+          console.error("NTP 서버에서 시간을 가져오는 데 실패했습니다.", err);
+          reject(err);  // 에러 발생 시 Promise를 reject
+          return;
+        }
+        
+        const seoulDate = new Date(moment(date)
+                .tz("Asia/Seoul")
+                .set({ second: 0, millisecond: 0 })
+                .valueOf() + (9 * 60 * 60 * 1000));
+
+        resolve(seoulDate); 
+      });
+    });
+}
+
+async function updateCachedTime() {
+    try {
+        const currentTime = await getCurrentTime();
+        cachedTime = currentTime;
+        console.log(cachedTime);
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+export function startTimeUpdate(refreshInterval: number) {
+    updateCachedTime(); // Initial call
+
+    setInterval(() => {
+        updateCachedTime();
+    }, refreshInterval);
+}

--- a/web/src/views/voteRooms/room.ejs
+++ b/web/src/views/voteRooms/room.ejs
@@ -28,7 +28,7 @@
                                         <h6 style="font-weight: bold;">투표상태</h6>
                                     </div>
                                     <div class="row state-badge-container">
-                                        <span class="state-badge badge bg-warning text-dark">예정</span>
+                                        <span class="state-badge badge bg-warning text-dark">투표중</span>
                                     </div>
                                 </div>
                             </div>                        


### PR DESCRIPTION
## 개요

- 투표방 접속 시 매번 ntp서버로 요청을 보내고 받아온 값을 통해 투표방의 상태를 확인 하는 것은 매우 비효율적.
- 투표 종료시간은 1시간 단위이므로 1분마다 ntp서버로 요청을 보내 cachedTime 변수에 저장 후 이를 재활용.